### PR TITLE
Add history id in file name if it exists

### DIFF
--- a/Invoke-Power-Nessie.ps1
+++ b/Invoke-Power-Nessie.ps1
@@ -240,7 +240,7 @@ Begin{
     $option7 = "7. Export PDF or CSV Report from Kibana dashboard and optionally send via Email (Advanced Options - Copy POST URL)."
     #$option10 = "10. Delete oldest scan from scan history (Future / Only works with Nessus Manager license)"
     $quit = "Q. Quit"
-    $version = "`nVersion 1.0.0"
+    $version = "`nVersion 1.0.1"
 
     function Show-Menu {
         Write-Host "Welcome to the PowerShell script that can export and ingest Nessus scan files into an Elastic stack!" -ForegroundColor Blue
@@ -421,7 +421,7 @@ Begin{
                 }
             } else {
                 $global:listOfScans | ForEach-Object {
-                    # Grab latest scan from Nessus.
+                    # Grab latest scan from Nessus
                     if($Nessus_Export_All_Scan_History -ne "true"){
                         Write-Host "Going to export $($_.name)"
                         export -scanId $($_.id) -scanName $($_.name)
@@ -464,7 +464,8 @@ Begin{
                 }else{
                     $convertedTime = $currentConvertedTime
                 }
-                $exportFileName = Join-Path $Nessus_File_Download_Location $($($convertedTime | Get-Date -Format yyyy_MM_dd).ToString()+"-$($scanName)"+"-$scanId-$historyId$($Nessus_Export_Custom_Extended_File_Name_Attribute).nessus")
+                $historyIdOrCreationDate = if($historyId){$historyId}else{$_.creation_date}
+                $exportFileName = Join-Path $Nessus_File_Download_Location $($($convertedTime | Get-Date -Format yyyy_MM_dd).ToString()+"-$($scanName)"+"-$scanId-$historyIdOrCreationDate$($Nessus_Export_Custom_Extended_File_Name_Attribute).nessus")
                 $exportComplete = 0
                 $currentScanIdStatus = $($global:currentNessusScanDataRaw.scans | Where-Object {$_.id -eq $scanId}).status
                 #Check to see if scan is not running or is an empty scan, if true then lets export!


### PR DESCRIPTION
If multiple scans are run on the same day, make the file name more unique by adding the history id if it exists.