### PR TITLE
add an ingest timestamp that makes my healthchecks happy

### DIFF
--- a/pipelines/logs-nessus.vulnerability.json
+++ b/pipelines/logs-nessus.vulnerability.json
@@ -68,6 +68,14 @@
       }
     },
     {
+      "set": {
+        "ignore_failure": true,
+        "ignore_empty_value": true,
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    },
+    {
       "script": {
         "source": "double score = ctx.nessus.cvss3.base_score;\r\n\r\ndef result;\r\n\r\nif (score >= 9.0) {\r\n  result = \"Critical\";\r\n} else if (score >= 7.0 && score < 9.0) {\r\n  result = \"High\";\r\n}else if (score > 4.0 && score < 7.0) {\r\n  result = \"Medium\";\r\n}else if (score > 0.0 && score < 4) {\r\n  result = \"Low\";\r\n}else if (score == 0.0) {\r\n  result = \"None\";\r\n}\r\n\r\nctx.vulnerability.severity = result;",
         "if": "ctx.nessus?.cvss3?.base_score != null",


### PR DESCRIPTION
I have some internal health checks to warn me if my Elastic fails to ingest data for some amount of time. I use this pattern across many of my indexes with various data rates from several events per second to just a few events per month.

This diff adds an additional field which I can use to set an appropriate alarm when it looks like my pipelines aren't processing enough.